### PR TITLE
Ensure `Backup` key has a valid value

### DIFF
--- a/schedule-ebs-snapshot-backups.py
+++ b/schedule-ebs-snapshot-backups.py
@@ -20,7 +20,7 @@ ec = boto3.client('ec2')
 def lambda_handler(event, context):
     reservations = ec.describe_instances(
         Filters=[
-            {'Name': 'tag-key', 'Values': ['backup', 'Backup']},
+            {'Name': 'tag:Backup', 'Values': ['true', 'yes', '1']},
         ]
     ).get(
         'Reservations', []


### PR DESCRIPTION
This tweaks the logic slightly to only snapshot instances that have a the `Backup` tag and it is set to a value of `true`, `yes` or `1`. Previously just the presence of the `Backup` tag (with any value) was enough to mark an instance for inclusion.

Signed-off-by: Seth Chisamore <schisamo@chef.io>